### PR TITLE
Migrate to Ktor 2.1.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,8 +13,8 @@ repositories {
 
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
-    implementation(libs.kotlin.gradle)
-    implementation(libs.android.gradle)
+    implementation(libs.plugin.android)
+    implementation(libs.plugin.gradle)
     implementation(libs.plugin.squareup.sqldelight)
     implementation(libs.plugin.dependency.check)
     implementation(libs.plugin.hilt)

--- a/buildSrc/src/main/kotlin/android-app-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-app-plugin.gradle.kts
@@ -70,7 +70,7 @@ android {
         implementation(libs.hilt.android)
         kapt(libs.hilt.compiler)
 
-        debugImplementation(libs.squareup.leakcanary)
+        debugImplementation(libs.leakcanary)
 
         coreLibraryDesugaring(libs.desugar)
     }

--- a/buildSrc/src/main/kotlin/android-app-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-app-plugin.gradle.kts
@@ -68,7 +68,6 @@ android {
         implementation(libs.inject)
         implementation(libs.kermit)
         implementation(libs.hilt.android)
-        implementation(libs.ktor.android)
         kapt(libs.hilt.compiler)
 
         debugImplementation(libs.squareup.leakcanary)

--- a/buildSrc/src/main/kotlin/android-compose-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-compose-plugin.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation(libs.androidx.compose.material.icons)
     api(libs.androidx.compose.ui.runtime)
     implementation(libs.androidx.compose.foundation)
-    api(libs.kotlinx.coroutines.jvm)
+    api(libs.coroutines.jvm)
     api(libs.androidx.compose.ui.tooling)
     implementation(libs.kenburns)
     implementation(libs.coil)

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ kotlin.native.binary.memoryModel=experimental
 import_orphan_source_sets=false
 
 # Allow kapt to use workers, incremental processing
-kapt.use.worker.api=true
 kapt.incremental.apt=true
 kapt.include.compile.classpath=false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,48 +1,30 @@
 [versions]
-kotlin = "1.6.10"
+kotlin = "1.6.21"
+agp = "7.3.0-rc01"
+compose = "1.2.0-beta01"
+accompanist = "0.24.6-alpha"
+coroutines = "1.6.1"
+hilt = "2.43.2"
+hiltNavigation = "1.0.0"
+hiltWork = "1.0.0"
+ktor = "2.1.0"
+multiplatform-paging = "0.4.7"
+sqldelight = "1.5.3"
+turbine = "0.7.0"
 
 android-compile = "33"
 android-target = "31"
 android-min = "23"
 
-android-gradle = "7.3.0-rc01"
-date-time = "0.3.2"
-
-accompanist = "0.24.6-alpha"
-snapper = "0.2.0"
-
 androidx-activity = "1.4.0"
 androidx-appCompat = "1.4.0"
 androidx-core = "1.8.0"
-androidx-compose = "1.2.0-alpha07"
-compose-compiler = "1.2.0-alpha07"
-androidx-composePaging = "1.0.0-alpha14"
-androidx-constraintlayout = "1.0.0"
+compose-compiler = "1.2.0-beta01"
 androidx-datastore = "1.0.0"
 androidx-lifecycle = "2.5.0-alpha06"
 androidx-navigation = "2.5.0-alpha04"
 androidx-palette = "1.0.0"
-androidx-paging = "3.1.0"
 androidx-workManager = "2.7.1"
-
-coil = "1.4.0"
-coroutines = "1.6.1"
-dagger = "2.41"
-desugar = "1.1.5"
-hilt = "2.43.2"
-hiltNavigation = "1.0.0"
-hiltWork = "1.0.0"
-inject = "1"
-kenburns = "1.0.7"
-kermit = "1.0.3"
-koin = "3.2.0-beta-1"
-ktor = "2.1.0"
-material = "1.6.0-alpha01"
-multiplatform-paging = "0.4.7"
-squareup-leakcanary = "2.8.1"
-sqldelight = "1.5.3"
-turbine = "0.7.0"
-youtubePlayer = "11.0.1"
 
 testing-arch-core = "2.1.0"
 testing-junit = "4.13.2"
@@ -59,12 +41,8 @@ plugin-detekt = "1.21.0"
 shared-module-version = "0.5.0"
 
 [libraries]
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "date-time" }
-
-kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlinx-coroutines-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "coroutines" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "coroutines" }
 
 accompanist-pager-core = { module = "com.google.accompanist:accompanist-pager", version.ref = "accompanist" }
 accompanist-pager-indicator = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
@@ -77,36 +55,31 @@ androidx-datastore = { module = "androidx.datastore:datastore-preferences", vers
 androidx-palette = { module = "androidx.palette:palette-ktx", version.ref = "androidx-palette" }
 androidx-workmanager = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-workManager" }
 
-androidx-compose-ui-runtime = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
-androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "androidx-compose" }
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
-androidx-compose-material-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidx-compose" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }
-androidx-compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "androidx-constraintlayout" }
+androidx-compose-ui-runtime = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+androidx-compose-material-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
-androidx-compose-paging = { module = "androidx.paging:paging-compose", version.ref = "androidx-composePaging" }
+androidx-compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version = "1.0.0" }
+androidx-compose-paging = { module = "androidx.paging:paging-compose", version = "1.0.0-alpha14" }
+androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version = "3.1.0" }
 
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 
 androidx-navigation-common = { module = "androidx.navigation:navigation-common-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "androidx-navigation" }
-
-androidx-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
-
-androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "androidx-paging" }
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-androidx-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltWork" }
 hilt-navigation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigation" }
 hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
-
-inject = { module = "javax.inject:javax.inject", version.ref = "inject" }
-koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 
 ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -116,27 +89,30 @@ ktor-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 
-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
-
-coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
-material = { module = "com.google.android.material:material", version.ref = "material" }
-kenburns = { module = "com.flaviofaria:kenburnsview", version.ref = "kenburns" }
-snapper = { module = "dev.chrisbanes.snapper:snapper", version.ref = "snapper" }
-youtubePlayer = { module = "com.pierfrancescosoffritti.androidyoutubeplayer:core", version.ref = "youtubePlayer" }
+coil = { module = "io.coil-kt:coil-compose", version = "1.4.0" }
+datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.3.2" }
+desugar = { module = "com.android.tools:desugar_jdk_libs", version = "1.1.5" }
+inject = { module = "javax.inject:javax.inject", version = "1" }
+kenburns = { module = "com.flaviofaria:kenburnsview", version = "1.0.7" }
+kermit = { module = "co.touchlab:kermit", version = "1.0.3" }
+koin = { module = "io.insert-koin:koin-core", version = "3.2.0-beta-1" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.8.1" }
+material = { module = "com.google.android.material:material", version = "1.6.0-alpha01" }
+snapper = { module = "dev.chrisbanes.snapper:snapper", version = "0.2.0" }
+youtubePlayer = { module = "com.pierfrancescosoffritti.androidyoutubeplayer:core", version = "11.0.1" }
 
 multiplatform-paging-core = { module = "io.github.kuuuurt:multiplatform-paging", version.ref = "multiplatform-paging" }
 multiplatform-paging-ios-x64 = { module = "io.github.kuuuurt:multiplatform-paging-iosX64", version.ref = "multiplatform-paging" }
 multiplatform-paging-ios-arm64 = { module = "io.github.kuuuurt:multiplatform-paging-iosArm64", version.ref = "multiplatform-paging" }
 
-squareup-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "squareup-leakcanary" }
 squareup-sqldelight-extensions = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 squareup-sqldelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqldelight" }
 squareup-sqldelight-driver-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 squareup-sqldelight-driver-jvm = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 squareup-sqldelight-driver-native = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqldelight" }
 
+plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+plugin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-dependency-check = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "plugin-gradle-versions" }
 plugin-hilt = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 plugin-buildkonfig = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "plugin-buildkonfig" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ inject = "1"
 kenburns = "1.0.7"
 kermit = "1.0.3"
 koin = "3.2.0-beta-1"
-ktor = "1.6.8"
+ktor = "2.1.0"
 material = "1.6.0-alpha01"
 multiplatform-paging = "0.4.7"
 squareup-leakcanary = "2.8.1"
@@ -108,10 +108,12 @@ hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
 inject = { module = "javax.inject:javax.inject", version.ref = "inject" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 
-ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-ios = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
+ktor-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
+ktor-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }

--- a/shared/core/database/build.gradle.kts
+++ b/shared/core/database/build.gradle.kts
@@ -16,14 +16,14 @@ kapt {
 }
 
 dependencies {
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
     commonMainImplementation(libs.squareup.sqldelight.runtime)
 
     androidMainImplementation(libs.squareup.sqldelight.driver.android)
     androidMainImplementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 
-    iosMainImplementation(libs.koin.core)
+    iosMainImplementation(libs.koin)
     iosMainImplementation(libs.squareup.sqldelight.driver.native)
 
     commonTestImplementation(kotlin("test"))

--- a/shared/core/network/build.gradle.kts
+++ b/shared/core/network/build.gradle.kts
@@ -14,9 +14,9 @@ android {
 }
 
 dependencies {
+    commonMainImplementation(libs.koin)
     commonMainImplementation(libs.ktor.core)
     commonMainImplementation(libs.ktor.logging)
-    commonMainImplementation(libs.koin.core)
     commonMainApi(libs.ktor.serialization)
     commonMainApi(libs.ktor.serialization.json)
     commonMainApi(libs.kermit)

--- a/shared/core/network/build.gradle.kts
+++ b/shared/core/network/build.gradle.kts
@@ -16,27 +16,20 @@ android {
 dependencies {
     commonMainImplementation(libs.ktor.core)
     commonMainImplementation(libs.ktor.logging)
-    commonMainImplementation(libs.ktor.serialization)
     commonMainImplementation(libs.koin.core)
-    commonMainImplementation(libs.kermit)
+    commonMainApi(libs.ktor.serialization)
+    commonMainApi(libs.ktor.serialization.json)
+    commonMainApi(libs.kermit)
 
     androidMainImplementation(project(":shared:core:util"))
 
-    androidMainImplementation(libs.ktor.android)
+    androidMainApi(libs.ktor.okhttp)
+    androidMainApi(libs.ktor.negotiation)
+    androidMainApi(libs.ktor.logging)
     androidMainImplementation(libs.squareup.sqldelight.driver.android)
     androidMainImplementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 
-    iosMainImplementation(libs.ktor.ios)
-
-    commonTestImplementation(kotlin("test"))
-    commonTestImplementation(project(":shared:core:test"))
-
-    commonTestImplementation(libs.testing.ktor.mock)
-    commonTestImplementation(libs.testing.turbine)
-    commonTestImplementation(libs.testing.kotest.assertions)
-    commonTestImplementation(libs.testing.mockk.common)
-
-    androidTestImplementation(kotlin("test"))
-    androidTestImplementation(libs.testing.androidx.junit)
+    iosMainApi(libs.ktor.serialization.json)
+    iosMainApi(libs.kermit)
 }

--- a/shared/core/network/src/androidMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
+++ b/shared/core/network/src/androidMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
@@ -1,66 +1,8 @@
 package com.thomaskioko.tvmaniac.network
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.android.Android
-import io.ktor.client.features.DefaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.LogLevel
-import io.ktor.client.features.logging.Logger
-import io.ktor.client.features.logging.Logging
-import io.ktor.client.features.observer.ResponseObserver
-import io.ktor.client.request.header
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.URLBuilder
-import kotlinx.serialization.json.Json
-import co.touchlab.kermit.Logger.Companion as KermitLogger
-
-private const val TIME_OUT = 60_000
 
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
 actual class KtorClientFactory {
-    actual fun build(httpUrl: String): HttpClient {
-        return HttpClient(Android) {
-            install(JsonFeature) {
-                serializer = KotlinxSerializer(
-                    Json {
-                        ignoreUnknownKeys = true
-                        prettyPrint = true
-                        isLenient = true
-                        explicitNulls = false
-                    }
-                )
-
-                engine {
-                    connectTimeout = TIME_OUT
-                    socketTimeout = TIME_OUT
-                }
-            }
-
-            install(Logging) {
-                level = LogLevel.INFO
-                logger = object : Logger {
-                    override fun log(message: String) {
-                        KermitLogger.d { message }
-                    }
-                }
-            }
-
-            install(ResponseObserver) {
-                onResponse { response ->
-                    KermitLogger.d { "HTTP status: ${response.status.value}" }
-                }
-            }
-
-            install(DefaultRequest) {
-                val endpointUrlBuilder = URLBuilder(httpUrl)
-                url {
-                    host = endpointUrlBuilder.host
-                    protocol = endpointUrlBuilder.protocol
-                }
-                header(HttpHeaders.ContentType, ContentType.Application.Json)
-            }
-        }
-    }
+    actual fun httpClient(httpClient: HttpClient): HttpClient = httpClient
 }

--- a/shared/core/network/src/commonMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
+++ b/shared/core/network/src/commonMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
@@ -3,5 +3,5 @@ package com.thomaskioko.tvmaniac.network
 import io.ktor.client.HttpClient
 
 expect class KtorClientFactory() {
-    fun build(httpUrl: String): HttpClient
+    fun httpClient(httpClient: HttpClient): HttpClient
 }

--- a/shared/core/network/src/iosMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
+++ b/shared/core/network/src/iosMain/kotlin/com/thomaskioko/tvmaniac/network/KtorClientFactory.kt
@@ -1,52 +1,10 @@
 package com.thomaskioko.tvmaniac.network
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.ios.Ios
-import io.ktor.client.features.DefaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.LogLevel
-import io.ktor.client.features.logging.Logger
-import io.ktor.client.features.logging.Logging
-import io.ktor.client.request.header
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.URLBuilder
-import co.touchlab.kermit.Logger.Companion as KermitLogger
+
 
 
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
 actual class KtorClientFactory {
-    actual fun build(httpUrl: String): HttpClient {
-        return HttpClient(Ios) {
-            install(JsonFeature) {
-                serializer = KotlinxSerializer(
-                    kotlinx.serialization.json.Json {
-                        ignoreUnknownKeys = true
-                        prettyPrint = true
-                        isLenient = true
-                        explicitNulls = false
-                    }
-                )
-            }
-
-            install(Logging) {
-                level = LogLevel.INFO
-                logger = object : Logger {
-                    override fun log(message: String) {
-                        KermitLogger.d { message }
-                    }
-                }
-            }
-
-            install(DefaultRequest) {
-                val endpointUrlBuilder = URLBuilder(httpUrl)
-                url {
-                    protocol = endpointUrlBuilder.protocol
-                    host = endpointUrlBuilder.host
-                }
-                header(HttpHeaders.ContentType, ContentType.Application.Json)
-            }
-        }
-    }
+    actual fun httpClient(httpClient: HttpClient): HttpClient = httpClient
 }

--- a/shared/core/network/src/iosMain/kotlin/com/thomaskioko/tvmaniac/network/di/Module.kt
+++ b/shared/core/network/src/iosMain/kotlin/com/thomaskioko/tvmaniac/network/di/Module.kt
@@ -2,11 +2,8 @@ package com.thomaskioko.tvmaniac.network.di
 
 import com.thomaskioko.tvmaniac.network.KtorClientFactory
 import org.koin.core.module.Module
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 actual fun networkPlatformModule(): Module = module {
-    single(named("tmdb-url")) {
-        KtorClientFactory().build(get(named("tmdb-url")))
-    }
+    single { KtorClientFactory().httpClient(get()) }
 }

--- a/shared/core/persistence/build.gradle.kts
+++ b/shared/core/persistence/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     androidMainImplementation(libs.androidx.datastore)
 
     commonMainImplementation(project(":shared:core:ui"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/core/test/build.gradle.kts
+++ b/shared/core/test/build.gradle.kts
@@ -9,5 +9,5 @@ android {
 }
 
 dependencies {
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/core/ui/build.gradle.kts
+++ b/shared/core/ui/build.gradle.kts
@@ -12,10 +12,10 @@ dependencies {
 
     androidMainImplementation(project(":shared:core:util"))
     androidMainImplementation(libs.inject)
-    androidMainImplementation(libs.koin.core)
+    androidMainImplementation(libs.koin)
 
-    commonMainImplementation(libs.kotlin.coroutines.core)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
+    commonMainImplementation(libs.coroutines.core)
 
-    iosMainImplementation(libs.koin.core)
+    iosMainImplementation(libs.koin)
 }

--- a/shared/core/util/build.gradle.kts
+++ b/shared/core/util/build.gradle.kts
@@ -11,12 +11,12 @@ android {
 
 dependencies {
 
+    commonMainImplementation(libs.koin)
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
     commonMainImplementation(libs.ktor.core)
-    commonMainImplementation(libs.kotlin.datetime)
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.datetime)
+    commonMainImplementation(libs.coroutines.core)
 
-    iosMainImplementation(libs.koin.core)
-    iosMainImplementation(libs.kotlin.datetime)
+    iosMainImplementation(libs.koin)
+    iosMainImplementation(libs.datetime)
 }

--- a/shared/core/util/src/androidMain/kotlin/com/thomaskioko/tvmaniac/core/util/ExceptionHandler.kt
+++ b/shared/core/util/src/androidMain/kotlin/com/thomaskioko/tvmaniac/core/util/ExceptionHandler.kt
@@ -1,8 +1,7 @@
 package com.thomaskioko.tvmaniac.core.util
 
 import co.touchlab.kermit.Logger
-import io.ktor.client.features.ResponseException
-import io.ktor.client.features.ServerResponseException
+import io.ktor.client.plugins.ServerResponseException
 import java.net.UnknownHostException
 
 actual object ExceptionHandler : Exception() {
@@ -19,10 +18,5 @@ actual object ExceptionHandler : Exception() {
     private fun Throwable.getErrorMessage(): String {
         Logger.e("Exception:: $message", this)
         return message ?: "Something went wrong"
-    }
-
-    private fun ResponseException.getErrorMessage(): String {
-        Logger.e("ResponseException:: $message", this)
-        return "Server Error: ${response.status.value} /n $message"
     }
 }

--- a/shared/domain/discover/api/build.gradle.kts
+++ b/shared/domain/discover/api/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
     commonMainImplementation(project(":shared:domain:show-common:api"))
 
     commonMainImplementation(libs.multiplatform.paging.core)
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 
 }

--- a/shared/domain/discover/implementation/build.gradle.kts
+++ b/shared/domain/discover/implementation/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
 
 
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
-    commonMainImplementation(libs.kotlin.datetime)
+    commonMainImplementation(libs.koin)
+    commonMainImplementation(libs.datetime)
     commonMainImplementation(libs.multiplatform.paging.core)
     commonMainImplementation(libs.squareup.sqldelight.extensions)
 

--- a/shared/domain/discover/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DiscoverRepositoryImpl.kt
+++ b/shared/domain/discover/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DiscoverRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.thomaskioko.tvmaniac.core.util.network.networkBoundResource
 import com.thomaskioko.tvmaniac.discover.api.cache.CategoryCache
 import com.thomaskioko.tvmaniac.discover.api.cache.DiscoverCategoryCache
 import com.thomaskioko.tvmaniac.discover.api.repository.DiscoverRepository
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 import com.thomaskioko.tvmaniac.showcommon.api.cache.TvShowCache
 import com.thomaskioko.tvmaniac.showcommon.api.model.ShowCategory
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbService

--- a/shared/domain/discover/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TvShowsCacheMapper.kt
+++ b/shared/domain/discover/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TvShowsCacheMapper.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.discover.implementation
 import com.thomaskioko.tvmaniac.core.db.SelectShows
 import com.thomaskioko.tvmaniac.core.db.Show
 import com.thomaskioko.tvmaniac.core.util.StringUtil
-import com.thomaskioko.tvmaniac.remote.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowResponse
 import kotlinx.datetime.toLocalDate
 
 fun List<SelectShows>.toShowList(): List<Show> {

--- a/shared/domain/discover/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/MockData.kt
+++ b/shared/domain/discover/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/MockData.kt
@@ -3,8 +3,8 @@ package com.thomaskioko.tvmaniac
 import com.thomaskioko.tvmaniac.core.db.Show
 import com.thomaskioko.tvmaniac.core.util.network.Resource
 import com.thomaskioko.tvmaniac.discover.api.DiscoverShowResult
-import com.thomaskioko.tvmaniac.remote.api.model.ShowResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 import com.thomaskioko.tvmaniac.showcommon.api.model.ShowCategory
 import com.thomaskioko.tvmaniac.showcommon.api.model.TvShow
 import kotlinx.coroutines.flow.flowOf

--- a/shared/domain/episodes/api/build.gradle.kts
+++ b/shared/domain/episodes/api/build.gradle.kts
@@ -11,5 +11,5 @@ android {
 dependencies {
     commonMainApi(project(":shared:core:util"))
     commonMainImplementation(project(":shared:core:database"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/episodes/implementation/build.gradle.kts
+++ b/shared/domain/episodes/implementation/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     commonMainImplementation(project(":shared:domain:episodes:api"))
 
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
     commonMainImplementation(libs.squareup.sqldelight.extensions)
 
     testImplementation(libs.testing.mockk.core)

--- a/shared/domain/episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/EpisodeMapper.kt
+++ b/shared/domain/episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/EpisodeMapper.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.implementation
 
 import com.thomaskioko.tvmaniac.core.util.StringUtil.formatPosterPath
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
 import com.thomaskioko.tvmaniac.core.db.Episode as EpisodeCache
 
 fun SeasonResponse.toEpisodeCacheList(): List<EpisodeCache> {

--- a/shared/domain/episodes/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MockData.kt
+++ b/shared/domain/episodes/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MockData.kt
@@ -3,8 +3,8 @@ package com.thomaskioko.tvmaniac.episodes.implementation
 import com.thomaskioko.tvmaniac.core.db.EpisodesBySeasonId
 import com.thomaskioko.tvmaniac.core.util.network.Resource
 import com.thomaskioko.tvmaniac.episodes.api.model.EpisodeUiModel
-import com.thomaskioko.tvmaniac.remote.api.model.EpisodesResponse
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.EpisodesResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
 import kotlinx.coroutines.flow.flowOf
 
 object MockData {

--- a/shared/domain/genre/api/build.gradle.kts
+++ b/shared/domain/genre/api/build.gradle.kts
@@ -11,5 +11,5 @@ android {
 dependencies {
     commonMainApi(project(":shared:core:util"))
     commonMainImplementation(project(":shared:core:database"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/genre/implementation/build.gradle.kts
+++ b/shared/domain/genre/implementation/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     commonMainImplementation(libs.squareup.sqldelight.extensions)
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
 
     commonTestImplementation(kotlin("test"))
     commonTestImplementation(project(":shared:core:test"))

--- a/shared/domain/last-air-episodes/api/build.gradle.kts
+++ b/shared/domain/last-air-episodes/api/build.gradle.kts
@@ -11,5 +11,5 @@ android {
 dependencies {
     commonMainApi(project(":shared:core:database"))
     commonMainApi(project(":shared:core:util"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/last-air-episodes/implementation/build.gradle.kts
+++ b/shared/domain/last-air-episodes/implementation/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     commonMainImplementation(project(":shared:domain:last-air-episodes:api"))
     commonMainImplementation(libs.squareup.sqldelight.extensions)
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
 
     testImplementation(libs.testing.mockk.core)
 

--- a/shared/domain/season-episodes/api/build.gradle.kts
+++ b/shared/domain/season-episodes/api/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     commonMainImplementation(project(":shared:core:database"))
     commonMainImplementation(project(":shared:domain:show-common:api"))
 
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/season-episodes/implementation/build.gradle.kts
+++ b/shared/domain/season-episodes/implementation/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
     commonMainImplementation(libs.squareup.sqldelight.extensions)
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
 
     testImplementation(libs.testing.mockk.core)
 

--- a/shared/domain/season-episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasonepisodes/implementation/Mapper.kt
+++ b/shared/domain/season-episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasonepisodes/implementation/Mapper.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.seasonepisodes.implementation
 
 import com.thomaskioko.tvmaniac.core.db.Episode
 import com.thomaskioko.tvmaniac.core.util.StringUtil
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
 
 fun SeasonResponse.toEpisodeCacheList(): List<Episode> {
     return episodes.map { episodeResponse ->

--- a/shared/domain/season-episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasonepisodes/implementation/SeasonWithEpisodesRepositoryImpl.kt
+++ b/shared/domain/season-episodes/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasonepisodes/implementation/SeasonWithEpisodesRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.thomaskioko.tvmaniac.core.db.SelectSeasonWithEpisodes
 import com.thomaskioko.tvmaniac.core.util.network.Resource
 import com.thomaskioko.tvmaniac.core.util.network.networkBoundResource
 import com.thomaskioko.tvmaniac.episodes.api.EpisodesCache
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
 import com.thomaskioko.tvmaniac.seasonepisodes.api.SeasonWithEpisodesCache
 import com.thomaskioko.tvmaniac.seasonepisodes.api.SeasonWithEpisodesRepository
 import com.thomaskioko.tvmaniac.seasons.api.SeasonsCache

--- a/shared/domain/seasons/api/build.gradle.kts
+++ b/shared/domain/seasons/api/build.gradle.kts
@@ -11,5 +11,5 @@ android {
 dependencies {
     commonMainApi(project(":shared:core:util"))
     commonMainImplementation(project(":shared:core:database"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/seasons/implementation/build.gradle.kts
+++ b/shared/domain/seasons/implementation/build.gradle.kts
@@ -17,13 +17,13 @@ dependencies {
 
     commonMainImplementation(project(":shared:core:database"))
     commonMainImplementation(project(":shared:domain:tmdb:api"))
-    commonMainImplementation(projects.shared.domain.seasons.api)
-    commonMainImplementation(projects.shared.domain.showDetails.implementation)
+    commonMainImplementation(project(":shared:domain:seasons:api"))
+    commonMainImplementation(project(":shared:domain:show-details:implementation"))
     commonMainImplementation(project(":shared:domain:show-common:api"))
 
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.koin)
+    commonMainImplementation(libs.coroutines.core)
     commonMainImplementation(libs.squareup.sqldelight.extensions)
 
     testImplementation(libs.testing.mockk.core)

--- a/shared/domain/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/mapper/SeasonsMapper.kt
+++ b/shared/domain/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/mapper/SeasonsMapper.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.seasons.implementation.mapper
 
 import com.thomaskioko.tvmaniac.core.db.Season
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
 
 fun ShowDetailResponse.toSeasonCacheList(): List<Season> {
     return seasons.map { seasonResponse ->

--- a/shared/domain/seasons/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/MockData.kt
+++ b/shared/domain/seasons/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/MockData.kt
@@ -1,9 +1,9 @@
 package com.thomaskioko.tvmaniac.seasons.implementation
 
 import com.thomaskioko.tvmaniac.core.db.Show
-import com.thomaskioko.tvmaniac.remote.api.model.GenreResponse
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonsResponse
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.GenreResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
 
 internal object MockData {
 

--- a/shared/domain/show-common/api/build.gradle.kts
+++ b/shared/domain/show-common/api/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     commonMainImplementation(project(":shared:core:util"))
     commonMainImplementation(project(":shared:core:database"))
 
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
     commonMainImplementation(libs.multiplatform.paging.core)
 
 }

--- a/shared/domain/show-details/api/build.gradle.kts
+++ b/shared/domain/show-details/api/build.gradle.kts
@@ -19,6 +19,6 @@ dependencies {
     commonMainImplementation(project(":shared:domain:trailers:api"))
 
     commonMainImplementation(libs.multiplatform.paging.core)
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 
 }

--- a/shared/domain/show-details/implementation/build.gradle.kts
+++ b/shared/domain/show-details/implementation/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
     commonMainImplementation(project(":shared:domain:trailers:api"))
 
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
-    commonMainImplementation(libs.kotlin.datetime)
+    commonMainImplementation(libs.koin)
+    commonMainImplementation(libs.datetime)
     commonMainImplementation(libs.multiplatform.paging.core)
     commonMainImplementation(libs.squareup.sqldelight.extensions)
 

--- a/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/mapper/TvShowsCacheMapper.kt
+++ b/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/mapper/TvShowsCacheMapper.kt
@@ -4,8 +4,8 @@ import com.thomaskioko.tvmaniac.core.db.Last_episode
 import com.thomaskioko.tvmaniac.core.db.SelectShows
 import com.thomaskioko.tvmaniac.core.db.Show
 import com.thomaskioko.tvmaniac.core.util.DateUtil.formatDateString
-import com.thomaskioko.tvmaniac.remote.api.model.LastEpisodeToAir
-import com.thomaskioko.tvmaniac.remote.api.model.NextEpisodeToAir
+import com.thomaskioko.tvmaniac.tmdb.api.model.LastEpisodeToAir
+import com.thomaskioko.tvmaniac.tmdb.api.model.NextEpisodeToAir
 
 fun List<SelectShows>.toShowList(): List<Show> {
     return map { it.toShow() }

--- a/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/mapper/TvShowsResponseMapper.kt
+++ b/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/mapper/TvShowsResponseMapper.kt
@@ -2,9 +2,9 @@ package com.thomaskioko.tvmaniac.details.implementation.mapper
 
 import com.thomaskioko.tvmaniac.core.db.Show
 import com.thomaskioko.tvmaniac.core.util.StringUtil.formatPosterPath
-import com.thomaskioko.tvmaniac.remote.api.model.GenreResponse
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
-import com.thomaskioko.tvmaniac.remote.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.GenreResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowResponse
 import kotlinx.datetime.toLocalDate
 
 fun ShowResponse.toShow(): Show {

--- a/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/repository/TvShowsRepositoryImpl.kt
+++ b/shared/domain/show-details/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/details/implementation/repository/TvShowsRepositoryImpl.kt
@@ -18,7 +18,7 @@ import com.thomaskioko.tvmaniac.details.implementation.mapper.toAirEp
 import com.thomaskioko.tvmaniac.details.implementation.mapper.toShow
 import com.thomaskioko.tvmaniac.details.implementation.mapper.toShowList
 import com.thomaskioko.tvmaniac.lastairepisodes.api.LastEpisodeAirCache
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
 import com.thomaskioko.tvmaniac.showcommon.api.cache.TvShowCache
 import com.thomaskioko.tvmaniac.showcommon.api.model.ShowCategory.POPULAR
 import com.thomaskioko.tvmaniac.showcommon.api.model.ShowCategory.TOP_RATED

--- a/shared/domain/show-details/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/MockData.kt
+++ b/shared/domain/show-details/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/MockData.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac
 
 import com.thomaskioko.tvmaniac.core.db.Show
-import com.thomaskioko.tvmaniac.remote.api.model.ShowResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 
 object MockData {
 

--- a/shared/domain/similar/api/build.gradle.kts
+++ b/shared/domain/similar/api/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     commonMainImplementation(project(":shared:core:database"))
     commonMainImplementation(project(":shared:domain:show-common:api"))
 
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/similar/implementation/build.gradle.kts
+++ b/shared/domain/similar/implementation/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     commonMainImplementation(project(":shared:domain:show-common:api"))
 
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
     commonMainImplementation(libs.squareup.sqldelight.extensions)
 
     testImplementation(libs.testing.mockk.core)

--- a/shared/domain/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/ResponseMapper.kt
+++ b/shared/domain/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/ResponseMapper.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.similar.implementation
 import com.thomaskioko.tvmaniac.core.db.Show
 import com.thomaskioko.tvmaniac.core.util.DateUtil.formatDateString
 import com.thomaskioko.tvmaniac.core.util.StringUtil
-import com.thomaskioko.tvmaniac.remote.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowResponse
 
 fun ShowResponse.toShow(): Show {
     return Show(

--- a/shared/domain/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowsRepositoryImpl.kt
+++ b/shared/domain/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowsRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.thomaskioko.tvmaniac.core.db.SelectSimilarShows
 import com.thomaskioko.tvmaniac.core.util.ExceptionHandler.resolveError
 import com.thomaskioko.tvmaniac.core.util.network.Resource
 import com.thomaskioko.tvmaniac.core.util.network.networkBoundResource
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 import com.thomaskioko.tvmaniac.showcommon.api.cache.TvShowCache
 import com.thomaskioko.tvmaniac.similar.api.SimilarShowCache
 import com.thomaskioko.tvmaniac.similar.api.SimilarShowsRepository

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/TmdbService.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/TmdbService.kt
@@ -1,10 +1,10 @@
 package com.thomaskioko.tvmaniac.tmdb.api
 
 import com.thomaskioko.tvmaniac.remote.api.model.GenresResponse
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TrailersResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TrailersResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 
 interface TmdbService {
 

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/EpisodesResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/EpisodesResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/GenreResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/GenreResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/GenresResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/GenresResponse.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.remote.api.model
 
+import com.thomaskioko.tvmaniac.tmdb.api.model.GenreResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/LastEpisodeToAir.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/LastEpisodeToAir.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/NextEpisodeToAir.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/NextEpisodeToAir.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/SeasonResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/SeasonResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/SeasonsResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/SeasonsResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/ShowDetailResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/ShowDetailResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/ShowResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/ShowResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TrailerResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TrailerResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TrailersResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TrailersResponse.kt
@@ -1,11 +1,10 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class TrailersResponse(
-
     @SerialName("id") val id: Int,
     @SerialName("results") val results: List<TrailerResponse>
 )

--- a/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TvShowsResponse.kt
+++ b/shared/domain/tmdb/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/api/model/TvShowsResponse.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.remote.api.model
+package com.thomaskioko.tvmaniac.tmdb.api.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/domain/tmdb/implementation/build.gradle.kts
+++ b/shared/domain/tmdb/implementation/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     commonMainImplementation(project(":shared:domain:tmdb:api"))
     commonMainImplementation(libs.ktor.core)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
 
     commonTestImplementation(kotlin("test"))
     commonTestImplementation(project(":shared:core:test"))

--- a/shared/domain/tmdb/implementation/build.gradle.kts
+++ b/shared/domain/tmdb/implementation/build.gradle.kts
@@ -19,9 +19,13 @@ android {
 dependencies {
 
     androidMainImplementation(project(":shared:core:network"))
-    androidMainImplementation(libs.ktor.android)
     androidMainImplementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
+
+    iosMainImplementation(project(":shared:core:network"))
+    iosMainImplementation(libs.ktor.negotiation)
+    iosMainImplementation(libs.ktor.logging)
+    iosMainImplementation(libs.ktor.darwin)
 
     commonMainImplementation(project(":shared:domain:tmdb:api"))
     commonMainImplementation(libs.ktor.core)
@@ -31,13 +35,13 @@ dependencies {
     commonTestImplementation(project(":shared:core:test"))
     commonTestImplementation(libs.ktor.serialization)
 
+    commonTestImplementation(libs.ktor.negotiation)
+    commonTestImplementation(libs.ktor.serialization.json)
     commonTestImplementation(libs.testing.ktor.mock)
     commonTestImplementation(libs.testing.turbine)
     commonTestImplementation(libs.testing.kotest.assertions)
     commonTestImplementation(libs.testing.mockk.common)
 
-    androidTestImplementation(kotlin("test"))
-    androidTestImplementation(libs.testing.androidx.junit)
 }
 
 buildkonfig {

--- a/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
+++ b/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.tmdb.implementation
+
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun tmdbPlatformModule(): Module = module { }

--- a/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/NetworkModule.kt
+++ b/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.tmdb.implementation
 
 import com.thomaskioko.tvmaniac.network.KtorClientFactory
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbService
+import com.thomaskioko.tvmaniac.tmdb.implementation.TmdbHttpClient.tmdbHttpClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,21 +16,19 @@ import javax.inject.Singleton
 object NetworkModule {
 
     @Provides
-    @Named("tmdb-url")
-    fun provideTmdbUrl(): String = "https://api.themoviedb.org"
+    fun provideTmdbInterceptor(): TmdbInterceptor = TmdbInterceptor()
 
     @Singleton
     @Provides
+    @Named("tmdb-http-client")
     fun provideHttpClient(
-        @Named("tmdb-url") url: String
-    ): HttpClient {
-        return KtorClientFactory().build(url)
-    }
+        tmdbInterceptor: TmdbInterceptor
+    ): HttpClient = KtorClientFactory().httpClient(tmdbHttpClient(tmdbInterceptor))
 
     @Singleton
     @Provides
     fun provideTvShowService(
-        httpClient: HttpClient
+        @Named("tmdb-http-client") httpClient: HttpClient
     ): TmdbService = TmdbServiceImpl(httpClient)
 
 }

--- a/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbHttpClient.kt
+++ b/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbHttpClient.kt
@@ -1,0 +1,51 @@
+package com.thomaskioko.tvmaniac.tmdb.implementation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import co.touchlab.kermit.Logger.Companion as KermitLogger
+
+
+object TmdbHttpClient {
+
+    @OptIn(ExperimentalSerializationApi::class)
+    fun tmdbHttpClient(tmdbInterceptor: TmdbInterceptor) = HttpClient(OkHttp) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    prettyPrint = true
+                    isLenient = true
+                    explicitNulls = false
+                }
+            )
+        }
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15000L
+            connectTimeoutMillis = 15000L
+            socketTimeoutMillis = 15000L
+        }
+
+        install(Logging) {
+            level = LogLevel.ALL
+            logger = object : Logger {
+                override fun log(message: String) {
+                    KermitLogger.d { message }
+                }
+            }
+        }
+
+        engine {
+            addInterceptor(tmdbInterceptor)
+        }
+
+    }
+}

--- a/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbInterceptor.kt
+++ b/shared/domain/tmdb/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbInterceptor.kt
@@ -1,0 +1,26 @@
+package com.thomaskioko.tvmaniac.tmdb.implementation
+
+import io.ktor.http.HttpHeaders
+import okhttp3.Interceptor
+import okhttp3.Response
+
+
+class TmdbInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var request = chain.request()
+        val urlBuilder = request.url.newBuilder()
+            .scheme("https")
+            .host("api.themoviedb.org")
+            .addQueryParameter("api_key", BuildKonfig.TMDB_API_KEY)
+            .build()
+
+
+        request = request.newBuilder()
+            .addHeader(HttpHeaders.ContentType, "application/json")
+            .addHeader(HttpHeaders.CacheControl, "public, max-age=" + 60 * 5)
+            .url(urlBuilder)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/shared/domain/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
+++ b/shared/domain/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
@@ -1,0 +1,5 @@
+package com.thomaskioko.tvmaniac.tmdb.implementation
+
+import org.koin.core.module.Module
+
+expect fun tmdbPlatformModule(): Module

--- a/shared/domain/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbServiceImpl.kt
+++ b/shared/domain/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbServiceImpl.kt
@@ -2,11 +2,12 @@ package com.thomaskioko.tvmaniac.tmdb.implementation
 
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbService
 import com.thomaskioko.tvmaniac.remote.api.model.GenresResponse
-import com.thomaskioko.tvmaniac.remote.api.model.SeasonResponse
-import com.thomaskioko.tvmaniac.remote.api.model.ShowDetailResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TrailersResponse
-import com.thomaskioko.tvmaniac.remote.api.model.TvShowsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.SeasonResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.ShowDetailResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TrailersResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TvShowsResponse
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 
@@ -14,62 +15,48 @@ class TmdbServiceImpl(
     private val httpClient: HttpClient,
 ) : TmdbService {
 
-    override suspend fun getTopRatedShows(page: Int): TvShowsResponse {
-        return httpClient.get("3/tv/top_rated") {
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
+    override suspend fun getTopRatedShows(page: Int): TvShowsResponse =
+        httpClient.get("3/tv/top_rated") {
             parameter("page", page)
             parameter("sort_by", "popularity.desc")
-        }
-    }
+        }.body()
 
-    override suspend fun getPopularShows(page: Int): TvShowsResponse {
-        return httpClient.get("3/tv/popular") {
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
+
+    override suspend fun getPopularShows(page: Int): TvShowsResponse =
+        httpClient.get("3/tv/popular") {
             parameter("page", page)
             parameter("sort_by", "popularity.desc")
-        }
-    }
+        }.body()
 
-    override suspend fun getSimilarShows(showId: Long): TvShowsResponse {
-        return httpClient.get("3/tv/$showId/recommendations"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
 
-    override suspend fun getRecommendations(showId: Long): TvShowsResponse {
-        return httpClient.get("3/tv/$showId/recommendations"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
+    override suspend fun getSimilarShows(showId: Long): TvShowsResponse =
+        httpClient.get("3/tv/$showId/recommendations")
+            .body()
 
-    override suspend fun getTvShowDetails(showId: Long): ShowDetailResponse {
-        return httpClient.get("3/tv/$showId"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
+    override suspend fun getRecommendations(showId: Long): TvShowsResponse =
+        httpClient.get("3/tv/$showId/recommendations")
+            .body()
 
-    override suspend fun getSeasonDetails(tvShowId: Long, seasonNumber: Long): SeasonResponse {
-        return httpClient.get("3/tv/$tvShowId/season/$seasonNumber"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
 
-    override suspend fun getTrendingShows(page: Int): TvShowsResponse {
-        return httpClient.get("3/trending/tv/week") {
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
+    override suspend fun getTvShowDetails(showId: Long): ShowDetailResponse =
+        httpClient.get("3/tv/$showId")
+            .body()
+
+
+    override suspend fun getSeasonDetails(tvShowId: Long, seasonNumber: Long): SeasonResponse =
+        httpClient.get("3/tv/$tvShowId/season/$seasonNumber")
+            .body()
+
+    override suspend fun getTrendingShows(page: Int): TvShowsResponse = httpClient
+        .get("3/trending/tv/week") {
             parameter("page", page)
-        }
-    }
+        }.body()
 
-    override suspend fun getAllGenres(): GenresResponse {
-        return httpClient.get("3/genre/tv/list"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
+    override suspend fun getAllGenres(): GenresResponse = httpClient
+        .get("3/genre/tv/list")
+        .body()
 
-    override suspend fun getTrailers(showId: Long): TrailersResponse {
-        return httpClient.get("3/tv/$showId/videos"){
-            parameter("api_key", BuildKonfig.TMDB_API_KEY)
-        }
-    }
+    override suspend fun getTrailers(showId: Long): TrailersResponse = httpClient
+        .get("3/tv/$showId/videos")
+        .body()
 }

--- a/shared/domain/tmdb/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/datasource/network/TvShowsServiceMockEngine.kt
+++ b/shared/domain/tmdb/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/datasource/network/TvShowsServiceMockEngine.kt
@@ -5,9 +5,8 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.features.defaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
 import io.ktor.content.TextContent
@@ -20,7 +19,9 @@ import io.ktor.http.Url
 import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.http.hostWithPort
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.date.GMTDate
+import kotlinx.serialization.json.Json
 import kotlin.test.assertEquals
 
 abstract class TvShowsServiceMockEngine {
@@ -49,9 +50,8 @@ abstract class TvShowsServiceMockEngine {
     }
 
     protected open fun httpClient() = HttpClient(MockEngine) {
-        install(JsonFeature) {
-            serializer = KotlinxSerializer(
-                kotlinx.serialization.json.Json {
+        install(ContentNegotiation) {
+            json(Json {
                     ignoreUnknownKeys = true
                     prettyPrint = true
                     isLenient = true

--- a/shared/domain/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
+++ b/shared/domain/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/Module.kt
@@ -4,6 +4,7 @@ import com.thomaskioko.tvmaniac.tmdb.api.TmdbService
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-val tmdbServiceModule: Module = module {
+actual fun tmdbPlatformModule(): Module = module {
+    factory { TmdbHttpClient.tmdbHttpClient() }
     single<TmdbService> { TmdbServiceImpl(get()) }
 }

--- a/shared/domain/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbHttpClient.kt
+++ b/shared/domain/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbHttpClient.kt
@@ -1,0 +1,63 @@
+package com.thomaskioko.tvmaniac.tmdb.implementation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.*
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLBuilder
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import co.touchlab.kermit.Logger.Companion as KermitLogger
+
+
+object TmdbHttpClient {
+
+    @OptIn(ExperimentalSerializationApi::class)
+    fun tmdbHttpClient(): HttpClient {
+        return HttpClient(Darwin) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        prettyPrint = true
+                        isLenient = true
+                        explicitNulls = false
+                    }
+                )
+            }
+
+            install(HttpTimeout) {
+                requestTimeoutMillis = 15000L
+                connectTimeoutMillis = 15000L
+                socketTimeoutMillis = 15000L
+            }
+
+
+            install(Logging) {
+                level = LogLevel.INFO
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        KermitLogger.d { message }
+                    }
+                }
+            }
+
+            install(DefaultRequest) {
+                val endpointUrlBuilder = URLBuilder("https://api.themoviedb.org")
+                url {
+                    protocol = endpointUrlBuilder.protocol
+                    host = endpointUrlBuilder.host
+                }
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+            }
+        }
+    }
+}

--- a/shared/domain/trailers/api/build.gradle.kts
+++ b/shared/domain/trailers/api/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     commonMainApi(project(":shared:core:util"))
     commonMainImplementation(project(":shared:core:ui"))
     commonMainImplementation(project(":shared:core:database"))
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.coroutines.core)
 }

--- a/shared/domain/trailers/implementation/build.gradle.kts
+++ b/shared/domain/trailers/implementation/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
 
     commonMainImplementation(libs.squareup.sqldelight.extensions)
     commonMainImplementation(libs.kermit)
-    commonMainImplementation(libs.koin.core)
+    commonMainImplementation(libs.koin)
 }

--- a/shared/domain/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shared/domain/trailers/implementation/TrailerRepositoryImpl.kt
+++ b/shared/domain/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shared/domain/trailers/implementation/TrailerRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.thomaskioko.tvmaniac.core.db.Trailers
 import com.thomaskioko.tvmaniac.core.util.ExceptionHandler.resolveError
 import com.thomaskioko.tvmaniac.core.util.network.Resource
 import com.thomaskioko.tvmaniac.core.util.network.networkBoundResource
-import com.thomaskioko.tvmaniac.remote.api.model.TrailersResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TrailersResponse
 import com.thomaskioko.tvmaniac.shared.domain.trailers.api.TrailerCache
 import com.thomaskioko.tvmaniac.shared.domain.trailers.api.TrailerRepository
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbService

--- a/shared/shared/build.gradle.kts
+++ b/shared/shared/build.gradle.kts
@@ -84,8 +84,8 @@ dependencies {
     commonMainImplementation(project(":shared:domain:trailers:implementation"))
     commonMainImplementation(project(":shared:domain:tmdb:implementation"))
 
-    commonMainImplementation(libs.koin.core)
-    commonMainImplementation(libs.kotlin.coroutines.core)
+    commonMainImplementation(libs.koin)
+    commonMainImplementation(libs.coroutines.core)
 }
 
 multiplatformSwiftPackage {

--- a/shared/shared/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shared/di/Koin.kt
+++ b/shared/shared/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shared/di/Koin.kt
@@ -16,7 +16,7 @@ import com.thomaskioko.tvmaniac.shared.core.ui.di.coreUiPlatformModule
 import com.thomaskioko.tvmaniac.shared.domain.trailers.implementation.di.trailersModule
 import com.thomaskioko.tvmaniac.showcommon.api.cache.TvShowCache
 import com.thomaskioko.tvmaniac.similar.implementation.di.similarDomainModule
-import com.thomaskioko.tvmaniac.tmdb.implementation.tmdbServiceModule
+import com.thomaskioko.tvmaniac.tmdb.implementation.tmdbPlatformModule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import org.koin.core.context.startKoin
@@ -27,7 +27,6 @@ import org.koin.dsl.module
 fun initKoin(appDeclaration: KoinAppDeclaration = {}) = startKoin {
     appDeclaration()
     modules(
-        tmdbServiceModule,
         cacheModule,
         dispatcherModule,
         detailDomainModule,
@@ -41,7 +40,8 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) = startKoin {
         trailersModule,
         coreUiPlatformModule(),
         dbPlatformModule(),
-        networkPlatformModule()
+        networkPlatformModule(),
+        tmdbPlatformModule()
     )
 }
 


### PR DESCRIPTION
## Shared Changes
- Migrate to Ktor 2.1.0.
- Move HTTP Client from Core network module to tmdb module. This should allow us to reuse the factory client.
- Use OkHTTP in place of Android for the HTTP client.

## Misc
- Cleanup dependencies in `libs.versions.toml`.