### PR TITLE
Kmmbridge

### DIFF
--- a/.github/workflows/kmmbridge-publish.yml
+++ b/.github/workflows/kmmbridge-publish.yml
@@ -1,0 +1,8 @@
+name: KMMBridge Publish Release
+on: workflow_dispatch
+
+jobs:
+  call-kmmbridge-publish:
+    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuildbranches.yml@v0.8
+    with:
+      jvmVersion: 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.dependency.analysis) apply false
+    alias(libs.plugins.kmmbridge) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.ksp) apply false
@@ -29,6 +30,7 @@ allprojects {
                         "androidTestFixtures",
                         "androidTestFixturesDebug",
                         "androidTestFixturesRelease",
+                        "androidTestFixturesDemo"
                     ).contains(it.name)
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 
-#Disable build cache. See #https://youtrack.jetbrains.com/issue/KT-49933/Support-Gradle-Configuration-caching-with-HMPP
-#org.gradle.unsafe.configuration-cache=true
-#org.gradle.unsafe.configuration-cache-problems=warn
-
 #Kotlin
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
@@ -28,5 +24,5 @@ android.defaults.buildfeatures.buildconfig=false
 #iOS
 xcodeproj=./ios
 
-#KMM
-kotlin.mpp.hierarchicalStructureSupport=false
+#KMMBridge
+GROUP=com.thomaskioko.tvmaniac

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ composecompiler = "1.4.5"
 coroutines = "1.6.4"
 desugar = "2.0.2"
 junit = "4.13.2"
+kmmbridge = "0.3.7"
 kotest = "5.5.4"
 kotlin = "1.8.20"
 kotlininject = "0.6.1"
@@ -119,6 +120,7 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 dependency-check = { id = "com.github.ben-manes.versions", version = "0.44.0" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version = "1.13.1" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.22.0" }
+kmmbridge = { id = "co.touchlab.faktory.kmmbridge", version.ref = "kmmbridge" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/shared/base/build.gradle.kts
+++ b/shared/base/build.gradle.kts
@@ -1,9 +1,7 @@
-
-import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
-
 plugins {
     id("tvmaniac.kmm.library")
-    id("com.chromaticnoise.multiplatform-swiftpackage") version "2.0.3"
+    id("maven-publish")
+    alias(libs.plugins.kmmbridge)
     alias(libs.plugins.ksp)
 }
 
@@ -18,28 +16,8 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "TvManiac"
-            isStatic = false
-            transitiveExport = true
+            isStatic = true
             linkerOpts.add("-lsqlite3")
-
-            embedBitcode(BitcodeEmbeddingMode.BITCODE)
-
-            export(projects.shared.core.database)
-            export(projects.shared.core.datastore.api)
-            export(projects.shared.core.tmdbApi.api)
-            export(projects.shared.data.episodes.api)
-            export(projects.shared.data.similar.api)
-            export(projects.shared.data.seasonDetails.api)
-            export(projects.shared.data.category.api)
-            export(projects.shared.data.trailers.api)
-            export(projects.shared.data.shows.api)
-            export(projects.shared.data.profile.api)
-            export(projects.shared.domain.discover)
-            export(projects.shared.domain.following)
-            export(projects.shared.domain.seasondetails)
-            export(projects.shared.domain.settings)
-            export(projects.shared.domain.showDetails)
-            export(projects.shared.domain.trailers)
         }
     }
 
@@ -47,30 +25,23 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(projects.shared.core.database)
-                api(projects.shared.core.datastore.api)
-                api(projects.shared.core.networkutil)
-                api(projects.shared.core.tmdbApi.api)
-                api(projects.shared.core.traktApi.api)
-                api(projects.shared.core.util)
-                api(projects.shared.data.category.api)
-                api(projects.shared.data.episodes.api)
-                api(projects.shared.data.similar.api)
-                api(projects.shared.data.seasonDetails.api)
-                api(projects.shared.data.shows.api)
-                api(projects.shared.data.trailers.api)
-                api(projects.shared.data.profile.api)
-                api(projects.shared.domain.discover)
-                api(projects.shared.domain.following)
-                api(projects.shared.domain.seasondetails)
-                api(projects.shared.domain.settings)
-                api(projects.shared.domain.seasondetails)
-                api(projects.shared.domain.showDetails)
-                api(projects.shared.domain.trailers)
-
+                implementation(projects.shared.core.database)
                 implementation(projects.shared.core.datastore.implementation)
-                implementation(projects.shared.core.tmdbApi.implementation)
+                implementation(projects.shared.core.networkutil)
+                implementation(projects.shared.core.traktApi.api)
                 implementation(projects.shared.core.traktApi.implementation)
+                implementation(projects.shared.core.tmdbApi.api)
+                implementation(projects.shared.core.tmdbApi.implementation)
+                implementation(projects.shared.core.util)
+
+                implementation(projects.shared.domain.discover)
+                implementation(projects.shared.domain.following)
+                implementation(projects.shared.domain.seasondetails)
+                implementation(projects.shared.domain.settings)
+                implementation(projects.shared.domain.seasondetails)
+                implementation(projects.shared.domain.showDetails)
+                implementation(projects.shared.domain.trailers)
+
                 implementation(projects.shared.data.category.implementation)
                 implementation(projects.shared.data.episodes.implementation)
                 implementation(projects.shared.data.profile.implementation)
@@ -79,7 +50,6 @@ kotlin {
                 implementation(projects.shared.data.shows.implementation)
                 implementation(projects.shared.data.trailers.implementation)
 
-                implementation(libs.coroutines.core)
                 implementation(libs.kotlinInject.runtime)
             }
         }
@@ -94,13 +64,6 @@ kotlin {
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
         }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-        }
     }
 }
 
@@ -113,13 +76,11 @@ android {
     namespace = "com.thomaskioko.tvmaniac.shared.base"
 }
 
-multiplatformSwiftPackage {
-    packageName("TvManiac")
-    swiftToolsVersion("5.3")
-    targetPlatforms {
-        iOS { v("13") }
-    }
+addGithubPackagesRepository()
 
-    distributionMode { local() }
-    outputDirectory(File("$projectDir/../../../", "tvmaniac-swift-packages"))
+kmmbridge {
+    frameworkName.set("TvManiac")
+    githubReleaseVersions()
+    spm()
+    versionPrefix.set("0.1")
 }

--- a/shared/base/src/iosMain/kotlin/com.thomaskioko.tvmaniac.shared/base/ApplicationComponent.kt
+++ b/shared/base/src/iosMain/kotlin/com.thomaskioko.tvmaniac.shared/base/ApplicationComponent.kt
@@ -25,7 +25,6 @@ import me.tatarka.inject.annotations.Component
 @ApplicationScope
 @Component
 abstract class ApplicationComponent :
-    UtilPlatformComponent,
     CategoryComponent,
     DatabaseComponent,
     DataStorePlatformComponent,
@@ -37,7 +36,8 @@ abstract class ApplicationComponent :
     SimilarShowsComponent,
     TmdbPlatformComponent,
     TraktPlatformComponent,
-    TrailerComponent {
+    TrailerComponent,
+    UtilPlatformComponent {
 
     abstract val discoverStateMachine: DiscoverStateMachineWrapper
     abstract val followingStateMachineWrapper: FollowingStateMachineWrapper

--- a/tooling/plugins/src/main/kotlin/AndroidLibraryPlugin.kt
+++ b/tooling/plugins/src/main/kotlin/AndroidLibraryPlugin.kt
@@ -1,4 +1,5 @@
 import com.android.build.gradle.LibraryExtension
+import com.thomaskioko.tvmaniac.extensions.configureFlavors
 import com.thomaskioko.tvmaniac.extensions.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -15,6 +16,7 @@ class AndroidLibraryPlugin : Plugin<Project> {
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
+                configureFlavors(this)
                 defaultConfig.targetSdk = 33
             }
 


### PR DESCRIPTION
This PR sets up Kmmbrige to help us publish Xcode Framework binaries. This also gets rid of `multiplatform-swiftpackage`, which is what we've been using.


Closes #69 